### PR TITLE
Added punctuation removal as argument to better normalize ref and hyp for scoring when punctuation isn't important

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ optional arguments:
                         Down-case the text before running the evaluation.
   -e, --remove-empty-refs
                         Skip over any examples where the reference is empty.
+  -P, --punctuation-insensitive
+                        Strip punctuation from text before running the evaluation.
 ```
 
 Contributing and code of conduct

--- a/asr_evaluation/__main__.py
+++ b/asr_evaluation/__main__.py
@@ -49,6 +49,8 @@ def get_parser():
                         help='Down-case the text before running the evaluation.')
     parser.add_argument('-e', '--remove-empty-refs', action='store_true',
                         help='Skip over any examples where the reference is empty.')
+    parser.add_argument('-P', '--punctuation-insensitive', action='store_true',
+                        help='Strip punctuation from text before running the evaluation.')
 
     return parser
 

--- a/asr_evaluation/asr_evaluation.py
+++ b/asr_evaluation/asr_evaluation.py
@@ -114,9 +114,7 @@ def process_line_pair(ref_line, hyp_line, case_insensitive=False, remove_empty_r
 
     # Split into tokens by whitespace
     ref = ref_line.split()
-    print(ref)
     hyp = hyp_line.split()
-    print(hyp)
     id_ = None
 
     # If the files have IDs, then split the ID off from the text

--- a/asr_evaluation/asr_evaluation.py
+++ b/asr_evaluation/asr_evaluation.py
@@ -131,8 +131,8 @@ def process_line_pair(ref_line, hyp_line, case_insensitive=False, remove_empty_r
     if remove_empty_refs and len(ref) == 0:
         return False
     if punctuation_insensitive:
-        ref = " ".join(map(str, ref)).translate(None, string.punctuation).split()
-        hyp = " ".join(map(str, hyp)).translate(None, string.punctuation).split()
+        ref = " ".join(ref).translate(None, string.punctuation).split()
+        hyp = " ".join(hyp).translate(None, string.punctuation).split()
 
     # Create an object to get the edit distance, and then retrieve the
     # relevant counts that we need.

--- a/asr_evaluation/asr_evaluation.py
+++ b/asr_evaluation/asr_evaluation.py
@@ -23,6 +23,7 @@ from collections import defaultdict
 from edit_distance import SequenceMatcher
 
 from termcolor import colored
+import string
 
 # Some defaults
 print_instances_p = False
@@ -73,7 +74,7 @@ def main(args):
     # Loop through each line of the reference and hyp file
     for ref_line, hyp_line in zip(args.ref, args.hyp):
         processed_p = process_line_pair(ref_line, hyp_line, case_insensitive=args.case_insensitive,
-                                        remove_empty_refs=args.remove_empty_refs)
+                                        remove_empty_refs=args.remove_empty_refs,punctuation_insensitive=args.punctuation_insensitive)
         if processed_p:
             counter += 1
     if confusions:
@@ -98,7 +99,7 @@ def main(args):
     print('SER: {:10.3%} ({:10d} / {:10d})'.format(ser, sent_error_count, counter))
 
 
-def process_line_pair(ref_line, hyp_line, case_insensitive=False, remove_empty_refs=False):
+def process_line_pair(ref_line, hyp_line, case_insensitive=False, remove_empty_refs=False, punctuation_insensitive=False):
     """Given a pair of strings corresponding to a reference and hypothesis,
     compute the edit distance, print if desired, and keep track of results
     in global variables.
@@ -113,7 +114,9 @@ def process_line_pair(ref_line, hyp_line, case_insensitive=False, remove_empty_r
 
     # Split into tokens by whitespace
     ref = ref_line.split()
+    print(ref)
     hyp = hyp_line.split()
+    print(hyp)
     id_ = None
 
     # If the files have IDs, then split the ID off from the text
@@ -129,6 +132,9 @@ def process_line_pair(ref_line, hyp_line, case_insensitive=False, remove_empty_r
         hyp = list(map(str.lower, hyp))
     if remove_empty_refs and len(ref) == 0:
         return False
+    if punctuation_insensitive:
+        ref = " ".join(map(str, ref)).translate(None, string.punctuation).split()
+        hyp = " ".join(map(str, hyp)).translate(None, string.punctuation).split()
 
     # Create an object to get the edit distance, and then retrieve the
     # relevant counts that we need.


### PR DESCRIPTION
I find some APIs return irregular punctuation so this strips all punctuation from ref and hyp before scoring.